### PR TITLE
Update selector for review author name

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = function (opt) {
 		rating: '.review-rating',
 		ratingPattern: 'a-star-',
 		text: '.review-text',
-		author: '.review-byline a',
+		author: '.a-profile-name',
 		date: '.review-date'
 	}
 	console.log(elDefaults)


### PR DESCRIPTION
Updates the selector for the review author name as it's changed on Amazon and this parser will always return "Not found".